### PR TITLE
feat: add ProtoConsent Core & Full lists

### DIFF
--- a/.github/workflows/refresh-full-lists.yml
+++ b/.github/workflows/refresh-full-lists.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           OK=0
           FAIL=0
-          for f in lists/*.json lists/*.txt; do
+          for f in lists/json/*.json lists/abp/*.txt lists/adguard/*.txt lists/hosts/*.txt lists/domains/*.txt; do
             if curl -sf "https://purge.jsdelivr.net/gh/ProtoConsent/data@main/$f" > /dev/null; then
               echo "Purged $f"
               OK=$((OK + 1))

--- a/LISTS.md
+++ b/LISTS.md
@@ -119,7 +119,18 @@ Regional lists appear in both the bundled and remote catalog as 2 aggregated ent
 
 The extension reads `rules[].condition` and creates `declarativeNetRequest` dynamic rules from them.
 
-### Full lists (`lists/`)
+### Profile lists (`lists/`)
+
+Pre-combined lists that merge multiple purposes into a single file. Available in all 5 formats (JSON, ABP, AdGuard, hosts, domains). Useful for Pi-hole, AdGuard Home, uBlock Origin, or any tool where subscribing to a single URL is simpler than combining individual purpose lists.
+
+| Profile | Included purposes | Description |
+|---------|-------------------|-------------|
+| Core (`protoconsent_core`) | ads, analytics, personalization, third_parties, advanced_tracking | All tracking-related purposes (mirrors extension's Balanced preset) |
+| Full (`protoconsent_full`) | ads, analytics, personalization, third_parties, advanced_tracking, security | All purposes including security (mirrors extension's Full preset) |
+
+Domains are deduplicated across purposes. The JSON format includes an `included_purposes` field listing which purposes were combined.
+
+### Per-purpose full lists (`lists/`)
 
 ```json
 {
@@ -133,6 +144,24 @@ The extension reads `rules[].condition` and creates `declarativeNetRequest` dyna
   "domain_count": 103328,
   "paths": ["||google.com/adsense/", "..."],
   "path_count": 1645
+}
+```
+
+### Profile lists (`lists/`)
+
+```json
+{
+  "name": "ProtoConsent Core",
+  "version": "2026-04-25",
+  "generated": "2026-04-25T...",
+  "description": "Full merged blocklist covering ads, analytics, personalization, third-party services, and advanced tracking",
+  "homepage": "https://github.com/ProtoConsent/data",
+  "license": "GPL-3.0-or-later",
+  "included_purposes": ["ads", "analytics", "personalization", "third_parties", "advanced_tracking"],
+  "domains": ["example-ad.com", "..."],
+  "domain_count": 156627,
+  "paths": ["||google.com/adsense/", "..."],
+  "path_count": 5870
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Part of the [ProtoConsent](https://github.com/ProtoConsent/ProtoConsent) project
 
 ## Blocklists
 
-Each purpose is available in five formats:
+Available in five formats:
 
 | Format | Path | Compatible with |
 |--------|------|-----------------|
@@ -31,6 +31,19 @@ Each purpose is available in five formats:
 | Hosts | `lists/hosts/` | Pi-hole, AdGuard Home, /etc/hosts |
 | Domains | `lists/domains/` | NextDNS, ControlD, RethinkDNS |
 | JSON | `lists/json/` | MV3 browser extensions, custom tools |
+
+### Combined lists
+
+For most users, a single combined list is the easiest option. Domains are deduplicated across purposes.
+
+| Profile | ABP | AdGuard | Hosts | Domains | JSON | Included purposes |
+|---------|-----|---------|-------|---------|------|-------------------|
+| Core | [abp](lists/abp/protoconsent_core.txt) | [adguard](lists/adguard/protoconsent_core.txt) | [hosts](lists/hosts/protoconsent_core.txt) | [domains](lists/domains/protoconsent_core.txt) | [json](lists/json/protoconsent_core.json) | Ads + Analytics + Personalization + Third Parties + Advanced Tracking |
+| Full | [abp](lists/abp/protoconsent_full.txt) | [adguard](lists/adguard/protoconsent_full.txt) | [hosts](lists/hosts/protoconsent_full.txt) | [domains](lists/domains/protoconsent_full.txt) | [json](lists/json/protoconsent_full.json) | All 6 purposes including Security |
+
+### Per-purpose lists
+
+For granular control, subscribe only to the purposes you want to block.
 
 | Purpose | ABP | AdGuard | Hosts | Domains | JSON | Description |
 |---------|-----|---------|-------|---------|------|-------------|
@@ -45,31 +58,27 @@ Updated weekly via GitHub Actions. See [LISTS.md](LISTS.md) for format details a
 
 ### Quick start
 
-**Pi-hole / AdGuard Home** (block ads + analytics):
+**Pi-hole / AdGuard Home** (block all tracking):
 ```
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/hosts/protoconsent_ads.txt
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/hosts/protoconsent_analytics.txt
+https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/hosts/protoconsent_core.txt
 ```
 
 **uBlock Origin** (custom filter list):
 ```
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/abp/protoconsent_ads.txt
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/abp/protoconsent_analytics.txt
+https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/abp/protoconsent_core.txt
 ```
 
 **AdGuard** (custom filter):
 ```
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/adguard/protoconsent_ads.txt
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/adguard/protoconsent_analytics.txt
+https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/adguard/protoconsent_core.txt
 ```
 
 **NextDNS / ControlD** (plain domains):
 ```
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/domains/protoconsent_ads.txt
-https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/domains/protoconsent_analytics.txt
+https://cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/domains/protoconsent_core.txt
 ```
 
-Subscribe to the purposes you want to block. Each list works independently.
+Replace `protoconsent_core` with `protoconsent_full` to include security (phishing/malware), or use individual purpose lists for granular control.
 
 Both `cdn.jsdelivr.net/gh/ProtoConsent/data@main/lists/...` (CDN, recommended) and `raw.githubusercontent.com/ProtoConsent/data/main/lists/...` (GitHub direct) work as subscription URLs.
 

--- a/scripts/generate-full-lists.js
+++ b/scripts/generate-full-lists.js
@@ -26,6 +26,19 @@ const PURPOSES = [
   "security",
 ];
 
+const PROFILES = {
+  core: {
+    label: "Core",
+    description: "Full merged blocklist covering ads, analytics, personalization, third-party services, and advanced tracking",
+    purposes: ["ads", "analytics", "personalization", "third_parties", "advanced_tracking"],
+  },
+  full: {
+    label: "Full",
+    description: "Full merged blocklist covering all purposes including security (phishing, scam, malware)",
+    purposes: ["ads", "analytics", "personalization", "third_parties", "advanced_tracking", "security"],
+  },
+};
+
 const BUNDLE_BASE =
   "https://raw.githubusercontent.com/ProtoConsent/ProtoConsent/main/extension/rules";
 
@@ -183,6 +196,7 @@ async function main() {
 
   const now = new Date().toISOString();
   const summary = [];
+  const purposeResults = new Map();
 
   for (const purpose of PURPOSES) {
     const label = PURPOSE_LABELS[purpose];
@@ -221,6 +235,8 @@ async function main() {
 
     const sortedDomains = [...allDomains].sort();
     const sortedPaths = [...allPaths].sort();
+
+    purposeResults.set(purpose, { domains: sortedDomains, paths: sortedPaths, version: version || new Date().toISOString().slice(0, 10) });
 
     summary.push({
       purpose,
@@ -313,6 +329,95 @@ async function main() {
 
     console.log(
       `  ${purpose}: ${sortedDomains.length} domains, ${sortedPaths.length} paths -> json | hosts | domains | abp | adguard`
+    );
+  }
+
+  // --- Profile lists (combined across purposes) ---
+  console.log();
+  for (const [profileId, profile] of Object.entries(PROFILES)) {
+    const allDomains = new Set();
+    const allPaths = new Set();
+    for (const purpose of profile.purposes) {
+      const result = purposeResults.get(purpose);
+      if (!result) continue;
+      result.domains.forEach((d) => allDomains.add(d));
+      result.paths.forEach((p) => allPaths.add(p));
+    }
+    const sortedDomains = [...allDomains].sort();
+    const sortedPaths = [...allPaths].sort();
+    const version = new Date().toISOString().slice(0, 10);
+    const label = profile.label;
+
+    summary.push({
+      purpose: profileId,
+      domains: sortedDomains.length,
+      paths: sortedPaths.length,
+    });
+
+    if (DRY_RUN) {
+      console.log(
+        `  ${profileId}: ${sortedDomains.length} domains, ${sortedPaths.length} paths (${profile.purposes.join(" + ")})`
+      );
+      continue;
+    }
+
+    // --- JSON output ---
+    const jsonOut = {
+      name: `ProtoConsent ${label}`,
+      version,
+      generated: now,
+      description: profile.description,
+      homepage: "https://github.com/ProtoConsent/data",
+      license: "GPL-3.0-or-later",
+      included_purposes: profile.purposes,
+      domains: sortedDomains,
+      domain_count: sortedDomains.length,
+      paths: sortedPaths,
+      path_count: sortedPaths.length,
+    };
+
+    const jsonPath = path.join(OUT_DIR, "json", `protoconsent_${profileId}.json`);
+    fs.writeFileSync(jsonPath, JSON.stringify(jsonOut, null, 2) + "\n");
+
+    // --- Hosts output ---
+    const hostsHeader = [
+      `# Title: ProtoConsent ${label}`,
+      `# Description: ${profile.description}`,
+      `# Version: ${version}`,
+      `# Last modified: ${now}`,
+      `# Entries: ${sortedDomains.length}`,
+      `# Homepage: https://github.com/ProtoConsent/data`,
+      `# License: GPL-3.0-or-later`,
+      `#`,
+    ];
+    const hostsLines = sortedDomains.map((d) => `0.0.0.0 ${d}`);
+    const hostsContent = hostsHeader.concat(hostsLines).join("\n") + "\n";
+    fs.writeFileSync(path.join(OUT_DIR, "hosts", `protoconsent_${profileId}.txt`), hostsContent);
+
+    // --- Domains output ---
+    const domainsHeader = [
+      `# Title: ProtoConsent ${label}`,
+      `# Description: ${profile.description}`,
+      `# Version: ${version}`,
+      `# Last modified: ${now}`,
+      `# Entries: ${sortedDomains.length}`,
+      `# Homepage: https://github.com/ProtoConsent/data`,
+      `# License: GPL-3.0-or-later`,
+      `#`,
+    ];
+    const domainsContent = domainsHeader.concat(sortedDomains).join("\n") + "\n";
+    fs.writeFileSync(path.join(OUT_DIR, "domains", `protoconsent_${profileId}.txt`), domainsContent);
+
+    // --- ABP output ---
+    const abpContent = generateAbp(label, profile.description, version, now, sortedDomains, sortedPaths);
+    fs.writeFileSync(path.join(OUT_DIR, "abp", `protoconsent_${profileId}.txt`), abpContent);
+
+    // --- AdGuard output ---
+    const adgContent = generateAdguard(label, profile.description, version, now, sortedDomains, sortedPaths);
+    fs.writeFileSync(path.join(OUT_DIR, "adguard", `protoconsent_${profileId}.txt`), adgContent);
+
+    console.log(
+      `  ${profileId}: ${sortedDomains.length} domains, ${sortedPaths.length} paths -> json | hosts | domains | abp | adguard (${profile.purposes.join(" + ")})`
     );
   }
 


### PR DESCRIPTION
## Summary

Add ProtoConsent Core & Full lists for easy aggregated consumption:
- Core: Ads + Analytics + Personalization + Third Parties + Advanced Tracking
- Full: All 6 purposes including Security